### PR TITLE
Remove package duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.1 2016-10-11
+* Remove duplicates of `eslint-plugin-mocha` and `eslint-plugin-react` in `package.json`.
+
 ### 1.0.0 2016-09-12
 * Rename package to `tictail-tide`
 * Public release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tictail-tide",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "lib/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "react": "^0.14.3 || ^15.0"
   },
   "dependencies": {
-    "eslint-plugin-mocha": "^2.2.0",
-    "eslint-plugin-react": "^5.0.1",
     "immutable": "^3.7.5",
     "immutablediff": "^0.4.2",
     "lodash.assign": "^3.2.0",


### PR DESCRIPTION
The packages `eslint-plugin-mocha` and `eslint-plugin-react` has duplicates in `package.json`. They were both in `dependencies` and `devDependencies` and should probably only be in `devDependencies`. 