### PR TITLE
Add option to emit change event immediately after updating the state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.1.0 2016-11-09
+* Add a parameter `{immediate: true}` to `setState`, `updateState` and `mutate` to make the change event emit immediately instead of deferring it. See `https://github.com/tictail/tide/issues/11`.
+
 ### 1.0.3 2016-10-13
 * Move package to `tide` on npm
 

--- a/example/app/actions/todo.js
+++ b/example/app/actions/todo.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import {Actions} from 'tictail-tide'
+import {Actions} from 'tide'
 import uuid from 'node-uuid'
 
 const STORAGE_KEY = 'todos-tide'
@@ -23,8 +23,11 @@ class TodoActions extends Actions {
   setTodoInputText(text) {
     // `this.mutate` mutates a value in the state at the given path.
     // This will trigger a re-render in the components that are listening
-    // to this value.
-    this.mutate('todoInputText', text)
+    // to this value. To preserve the position of the cursor when changing
+    // this value, we need to tell Tide to make the change immediately instead
+    // of applying it asynchronously. You can read more about this behavior in
+    // the docs.
+    this.mutate('todoInputText', text, {immediate: true})
   }
 
   addTodo() {
@@ -63,7 +66,7 @@ class TodoActions extends Actions {
   }
 
   changeTitle(todoKeyPath, value) {
-    this.mutate(todoKeyPath.concat(['title']), value)
+    this.mutate(todoKeyPath.concat(['title']), value, {immediate: true})
     this.storeTodos()
   }
 

--- a/example/app/router.jsx
+++ b/example/app/router.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import {Route, Router, browserHistory} from 'react-router'
-import {Component as TideComponent} from 'tictail-tide'
+import {Component as TideComponent} from 'tide'
 
 import Tide from 'app/tide'
 import App from 'app/screens/app/index'

--- a/example/app/screens/todo/components/footer/index.jsx
+++ b/example/app/screens/todo/components/footer/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Link} from 'react-router'
-import {wrap} from 'tictail-tide'
+import {wrap} from 'tide'
 import classNames from 'classnames'
 
 const FILTERS = [

--- a/example/app/screens/todo/components/header/todo-input.jsx
+++ b/example/app/screens/todo/components/header/todo-input.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {wrap} from 'tictail-tide'
+import {wrap} from 'tide'
 
 const TodoInput = React.createClass({
   onChange(e) {

--- a/example/app/screens/todo/components/main-section/index.jsx
+++ b/example/app/screens/todo/components/main-section/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {wrap} from 'tictail-tide'
+import {wrap} from 'tide'
 
 import ToggleAll from './toggle-all'
 import TodoList from './todo-list'

--- a/example/app/screens/todo/components/main-section/todo-list.jsx
+++ b/example/app/screens/todo/components/main-section/todo-list.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {wrap, Component as TideComponent} from 'tictail-tide'
+import {wrap, Component as TideComponent} from 'tide'
 
 import TodoItem from './todo-item'
 

--- a/example/app/screens/todo/components/main-section/toggle-all.jsx
+++ b/example/app/screens/todo/components/main-section/toggle-all.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {wrap} from 'tictail-tide'
+import {wrap} from 'tide'
 
 const ToggleAll = React.createClass({
   onChange() {

--- a/example/app/tide.js
+++ b/example/app/tide.js
@@ -1,4 +1,4 @@
-import {Base} from 'tictail-tide'
+import {Base} from 'tide'
 
 import State from 'app/state'
 import TodoActions from 'app/actions/todo'

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-router": "^2.7.0",
-    "tictail-tide": "^1.0.0",
+    "tide": "~1.1.0",
     "todomvc-app-css": "^2.0.1"
   },
   "devDependencies": {

--- a/example/webpack.config.babel.js
+++ b/example/webpack.config.babel.js
@@ -5,7 +5,8 @@ import HtmlWebpackPlugin from 'html-webpack-plugin'
 
 module.exports = {
   resolveLoader: {
-    moduleDirectories: ['node_modules']
+    moduleDirectories: ['node_modules'],
+    fallback: path.join(__dirname, 'node_modules'),
   },
 
   output: {
@@ -22,25 +23,21 @@ module.exports = {
     }
   },
 
-  resolveLoader: {
-    fallback: path.join(__dirname, 'node_modules')
-  },
-
   module: {
     loaders: [
-      { test: /\.css$/, loaders: ['style', 'css'] },
-      { test: /\.scss$/, loaders: ['style', 'css', 'postcss-loader', 'sass'] },
-      { test: /\.json$/, loaders: ['json-loader'] },
+      {test: /\.css$/, loaders: ['style', 'css']},
+      {test: /\.scss$/, loaders: ['style', 'css', 'postcss-loader', 'sass']},
+      {test: /\.json$/, loaders: ['json-loader']},
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
         exclude: /node_modules/,
-        query: { presets: ['es2015', 'react', 'stage-2'] }
+        query: {presets: ['es2015', 'react', 'stage-2']}
       }
     ]
   },
 
-  postcss: [autoprefixer({ browsers: ['last 2 version'] })],
+  postcss: [autoprefixer({browsers: ['last 2 version']})],
 
   devtool: 'eval',
   debug: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tide",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A Flux-like State Management Library for React by your friends at Tictail.",
   "main": "lib/index.js",
   "license": "MIT",

--- a/src/actions.js
+++ b/src/actions.js
@@ -8,16 +8,16 @@ class Actions {
     return this.tide.getState()
   }
 
-  setState(state) {
-    this.tide.setState(state)
+  setState(state, options) {
+    this.tide.setState(state, options)
   }
 
-  updateState(updater) {
-    this.tide.updateState(updater)
+  updateState(updater, options) {
+    this.tide.updateState(updater, options)
   }
 
-  mutate(keyPath, value) {
-    this.tide.mutate(keyPath, value)
+  mutate(keyPath, value, options) {
+    this.tide.mutate(keyPath, value, options)
   }
 
   get(keyPath) {

--- a/src/base.js
+++ b/src/base.js
@@ -22,20 +22,20 @@ class Base {
     return this.state
   }
 
-  setState(state) {
+  setState(state, options) {
     this.logStateUpdate(this.state, state)
     this.state = state
-    this.emitChange()
+    this.emitChange(options)
   }
 
-  updateState(updater) {
-    this.setState(updater(this.state))
+  updateState(updater, options) {
+    this.setState(updater(this.state), options)
   }
 
-  mutate(keyPath, value) {
+  mutate(keyPath, value, options) {
     const kp = isArray(keyPath) ? keyPath : keyPath.split('.')
     const val = typeof value === 'function' ? value(this.getState().getIn(kp)) : value
-    this.setState(this.getState().setIn(kp, val))
+    this.setState(this.getState().setIn(kp, val), options)
   }
 
   get(keyPath) {
@@ -133,13 +133,16 @@ class Base {
     forEach(this.changeHandlers, (fn) => { fn && fn() })
   }
 
-  emitChange() {
-    if (this._willEmit) return
-    this._willEmit = true
-    defer(() => {
-      this._willEmit = false
+  emitChange(options = {}) {
+    if (options.immediate) {
       this.emit()
-    })
+    } else if (!this._willEmit) {
+      this._willEmit = true
+      defer(() => {
+        this._willEmit = false
+        this.emit()
+      })
+    }
   }
 }
 /* eslint-enable no-console */

--- a/src/component.js
+++ b/src/component.js
@@ -60,7 +60,6 @@ class Component extends React.Component {
 
   onStateChange() {
     if (this._isUnmounting) return
-    this._keyPaths = this.getKeyPaths(this.props)
     const newState = this.getPropsFromKeyPaths(this._keyPaths, this.getTide())
     if (this.hasStaleState(newState)) {
       this.setState(newState)


### PR DESCRIPTION
This fixes #11 as discussed in the comments there. 

Changes:
* Add a parameter `{immediate: true}` to `setState`, `updateState` and `mutate` to make the change event emit immediately.
* Remove an unnecessary key path calculation in the component before checking for state changes, since this is already calculated and cached in `componentsWillReceiveProps` which is the only place where the key paths can change.  
* Bump package to `1.1.0`
* Bump the example app to use `tide@1.1.0` and change the appropriate `mutate` calls to use the new flag.

@eldh would be great to get #9 merged before this to use the NPM deploy script. 
