### PR TITLE
Add ability to define a key path as a function of the current state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.2.0 2016-11-21
+* Added support for defining a key path as a function in a Tide component. The function receives the current state as its only argument, and should return the key path in one of the other supported forms.
+
 ### 1.1.0 2016-11-09
 * Add a parameter `{immediate: true}` to `setState`, `updateState` and `mutate` to make the change event emit immediately instead of deferring it. See `https://github.com/tictail/tide/issues/11`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tide",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A Flux-like State Management Library for React by your friends at Tictail.",
   "main": "lib/index.js",
   "license": "MIT",
@@ -59,6 +59,7 @@
     "lodash.defer": "^4.0.0",
     "lodash.foreach": "^3.0.3",
     "lodash.isarray": "^3.0.4",
+    "lodash.isfunction": "^3.0.8",
     "lodash.keys": "^3.1.2",
     "lodash.mapvalues": "^3.0.1",
     "lodash.omit": "^3.1.0",


### PR DESCRIPTION
This adds the option to define a key path in a Tide component as a function that takes the current state and returns a key path based on that. This allows you to use values in the state as pointers to other parts of it. 

Let's say you have a state object with a bunch of items that you can navigate between: 
```js
state = Immutable.fromJS({
  items: {
    15: {id: 15, title: "foo", ...}
    23: {id: 23, title: "bar", ...}
    64: {id: 64, title: "baz", ...}
  }
  currentItemId: 23  
})
```
In this case `currentItemId` is the id of the item that you are currently looking at. To create a component that renders that item with the current Tide API, we would need to do something similar to this:

```js
const ItemWrapper = ({currentItemId}) =>
  <TideComponent item={['items', currentItemId]}>
    <Item />
  </TideComponent>

const Item = ({item}) => 
   <div>{item.get('title')}</div>

export default wrap(ItemWrapper, {currentItemId: 'currentItemId'})
```  

After the changes made in this PR, this becomes a lot simpler: 

```js
const Item = ({item}) => 
   <div>{item.get('title')}</div>

export default wrap(Item, {item: (state) => ['items', state.get('currentItemId')]})
```

There are of course other ways to work around the problem described above, but I think this addition provides a powerful tool for components to access the state in different ways. 