### PR TITLE
Fix tide context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+### 1.2.1 2016-11-23
+* Fix breaking bug introduced in 1.2.0 when trying to access `tide` from context in `TideComponent`
+* Fix breaking bug when trying to directly nest multiple `TideComponent`s
+
 ### 1.2.0 2016-11-21
-* Added support for defining a key path as a function in a Tide component. The function receives the current state as its only argument, and should return the key path in one of the other supported forms.
+* Add support for defining a key path as a function in a Tide component. The function receives the current state as its only argument, and should return the key path in one of the other supported forms.
 
 ### 1.1.0 2016-11-09
 * Add a parameter `{immediate: true}` to `setState`, `updateState` and `mutate` to make the change event emit immediately instead of deferring it. See `https://github.com/tictail/tide/issues/11`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tide",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Flux-like State Management Library for React by your friends at Tictail.",
   "main": "lib/index.js",
   "license": "MIT",

--- a/src/component.js
+++ b/src/component.js
@@ -6,6 +6,8 @@ import isFunction from 'lodash.isfunction'
 import mapValues from 'lodash.mapvalues'
 import omit from 'lodash.omit'
 
+import TideBase from './base'
+
 const displayName = 'TideComponent'
 const contextTypes = {tide: React.PropTypes.object}
 const childContextTypes = {tide: React.PropTypes.object}
@@ -87,7 +89,7 @@ class Component extends React.Component {
   }
 
   getTide() {
-    return this.props.tide || this.context.tide
+    return this.props.tide instanceof TideBase ? this.props.tide : this.context.tide
   }
 
   getChildProps() {

--- a/src/component.js
+++ b/src/component.js
@@ -29,7 +29,7 @@ const excludedProps = NOT_KEY_PATH_PROPS.reduce((val, prop) => {
 
 class Component extends React.Component {
   constructor(props, context) {
-    super(props)
+    super(props, context)
     const tide = this.getTide()
     const keyPaths = this.getKeyPaths(props, tide)
     this._componentTide = {

--- a/test/component_test.coffee
+++ b/test/component_test.coffee
@@ -37,6 +37,23 @@ describe "TideComponent", ->
       )
       TestUtils.renderIntoDocument tree
 
+    it "uses tide from context instead of props when directly nesting multiple components", ->
+      tide = @tide
+      Child = React.createClass
+        contextTypes:
+          tide: React.PropTypes.object
+
+        render: ->
+          @context.tide.should.equal tide
+          null
+
+      tree = React.createElement(TideComponent, {tide: @tide},
+        React.createElement(TideComponent, {},
+          React.createElement(Child)
+        )
+      )
+      TestUtils.renderIntoDocument tree
+
   describe "Props", ->
     it "passes down the data of the given key paths as props to the child", ->
       Child = createComponent ->
@@ -173,7 +190,6 @@ describe "TideComponent", ->
     it "re-renders when a dynamic key path changes", (done) ->
       spy = Sinon.spy()
       Child = createComponent ->
-        console.log this.props.pointer
         spy(this.props.pointer)
 
       @tide.setState Immutable.Map(

--- a/test/component_test.coffee
+++ b/test/component_test.coffee
@@ -28,7 +28,13 @@ describe "TideComponent", ->
           @context.tide.should.equal tide
           null
 
-      tree = React.createElement TideComponent, {tide: @tide}, React.createElement(Child)
+      tree = React.createElement(TideComponent, {tide: @tide},
+        React.createElement("div", {},
+          React.createElement(TideComponent, {},
+            React.createElement(Child)
+          )
+        )
+      )
       TestUtils.renderIntoDocument tree
 
   describe "Props", ->


### PR DESCRIPTION
I managed to introduce a bug in 1.2.0 that caused TideComponents to throw an error when trying to access `tide` from the context. We always had the Tide instance available through the prop in our tests, so I changed the one where we test context to do that in a deeper tree. 

I also noticed that we get an error when directly nesting multiple TideComponents inside each other, since we misinterpret the `tide` namespace prop as the Tide instance object in the nested component. That bug is also fixed now. 