### PR TITLE
Bump Tide version in the example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To explain the benefits of keeping this value in our global state, let’s take 
 ```JavaScript
 import Immutable from 'immutable'
 import {Actions} from 'tide'
-import uuid from 'node-uuid'
+import uuid from 'uuid'
 
 class TodoActions extends Actions {
   setTodoInputText(text) {

--- a/README.md
+++ b/README.md
@@ -76,16 +76,16 @@ The final code snippet to tie this example together is our input field component
 import React from 'react'
 import {wrap} from 'tide'
 
-const TodoInput = React.createClass({
-  onChange(e) {
+class TodoInput extends React.Component {
+  onChange = (e) => {
     this.props.tide.actions.todo.setTodoInputText(e.target.value)
-  },
+  }
 
-  onKeyPress(e) {
+  onKeyPress = (e) => {
     if (e.key === 'Enter') {
       this.props.tide.actions.todo.addTodo()
     }
-  },
+  }
 
   render() {
     return (

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Head on over to [the wiki](https://github.com/tictail/tide/wiki) for the full do
 
 For bugs and feature requests, please open an issue. If you'd like to contribute, create a new PR
 with your changes. Make sure you include tests, bump the version in `package.json` according to
-[semantic versioning](http://semver.org/) and update the [CHANGELOG](changelog.md) (if applicable).
+[semantic versioning](http://semver.org/) and update the [CHANGELOG](CHANGELOG.md) (if applicable).
 
 ## License
 

--- a/example/app/actions/todo.js
+++ b/example/app/actions/todo.js
@@ -1,6 +1,6 @@
 import Immutable from 'immutable'
 import {Actions} from 'tide'
-import uuid from 'node-uuid'
+import uuid from 'uuid'
 
 const STORAGE_KEY = 'todos-tide'
 // Actions are a set of methods that handle updates

--- a/example/app/screens/todo/components/header/index.jsx
+++ b/example/app/screens/todo/components/header/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import TodoInput from './todo-input'
 
-export default class extends React.Component {
+class Header extends React.Component {
   render() {
     return (
       <header className='header'>
@@ -11,3 +11,5 @@ export default class extends React.Component {
     )
   }
 }
+
+export default Header

--- a/example/app/screens/todo/components/main-section/todo-item.jsx
+++ b/example/app/screens/todo/components/main-section/todo-item.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 
-export default class extends React.Component {
+class TodoItem extends React.Component {
   state = {
     editing: false,
     lastTitle: null,
@@ -86,3 +86,5 @@ export default class extends React.Component {
     )
   }
 }
+
+export default TodoItem

--- a/example/app/screens/todo/index.jsx
+++ b/example/app/screens/todo/index.jsx
@@ -4,7 +4,7 @@ import Header from './components/header'
 import MainSection from './components/main-section'
 import Footer from './components/footer'
 
-export default class extends React.Component {
+class Todo extends React.Component {
   render() {
     return (
       <div className='todo-screen'>
@@ -15,3 +15,5 @@ export default class extends React.Component {
     )
   }
 }
+
+export default Todo

--- a/example/package.json
+++ b/example/package.json
@@ -4,14 +4,14 @@
   "dependencies": {
     "classnames": "^2.1.3",
     "immutable": "^3.7.5",
-    "node-uuid": "^1.4.3",
     "query-string": "^2.4.1",
     "qwest": "2.0.5",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-router": "^2.7.0",
     "tide": "2.0.0-alpha.3",
-    "todomvc-app-css": "^2.0.1"
+    "todomvc-app-css": "^2.0.1",
+    "uuid": "~3.0.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,6 @@
   "dependencies": {
     "classnames": "^2.1.3",
     "immutable": "^3.7.5",
-    "query-string": "^2.4.1",
-    "qwest": "2.0.5",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-router": "^2.7.0",

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-router": "^2.7.0",
-    "tide": "~1.2.1",
+    "tide": "2.0.0-alpha.3",
     "todomvc-app-css": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR will:

- Bump the Tide version in the example app to `2.0.0-alpha.3`
- Export components in a consistent manner
- Replace the deprecated `node-uuid` package with `uuid`.
- Remove unused packages
- Update README.md