### PR TITLE
Replace react-pure-render with shallowequal

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "lodash.mapvalues": "^4.6.0",
     "lodash.wrap": "^4.1.1",
     "prop-types": "~15.5.8",
-    "react-pure-render": "^1.0.2"
+    "shallowequal": "^1.0.1"
   }
 }

--- a/src/component.js
+++ b/src/component.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import shallowEqual from 'react-pure-render/shallowEqual'
+import shallowEqual from 'shallowequal'
 import mapValues from 'lodash.mapvalues'
 import Tide from './base'
 

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import shallowEqual from 'react-pure-render/shallowEqual'
+import shallowEqual from 'shallowequal'
 
 import TideComponent from './component'
 


### PR DESCRIPTION
This packages does the same thing but without any extras. The reason for me to throw out `react-pure-render` is only because its `.babelrc` file is using legacy Babel options requiring users to install extra packages.