### PR TITLE
change setTimeout(fn, 1) to setTimeout(fn, 0) for better performance

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -1,5 +1,5 @@
 function defer(fn) {
-  setTimeout(fn, 1)
+  setTimeout(fn, 0)
 }
 
 function getNextState(oldState, newState) { return newState }


### PR DESCRIPTION
From the name of this method(`defer`), I'm guessing that it's used for delaying `fn` to the next event loop. Then `setTimeout(fn, 0)` is enough and have a little performance gain.