### PR TITLE
Update tide example to have working toggle all button

### DIFF
--- a/example/app/screens/todo/components/main-section/toggle-all.jsx
+++ b/example/app/screens/todo/components/main-section/toggle-all.jsx
@@ -14,6 +14,7 @@ class ToggleAll extends React.Component {
           checked={all}
           onChange={this.onChange}
           className="toggle-all"
+          id="toggle-all"
           type="checkbox"
         />
         <label htmlFor="toggle-all">


### PR DESCRIPTION
The toggle all button in the Tide example was previously not functional as it was not tied to the label using the id tag.