### PR TITLE
Add a meta data prop that is passed to keypath functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.1.0 2018-01-12
+* Add a new special property `tidePointer` on `TideComponent`. The `tidePointer` prop is an object that is supplied as the second argument to keypath functions. See https://github.com/tictail/tide/pull/29. 
+
 ### 2.0.0 2017-06-20
 * Replace `react-pure-render/shallowEqual` with `shallowequal` 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 2.1.0 2018-01-12
-* Add a new special property `tidePointer` on `TideComponent`. The `tidePointer` prop is an object that is supplied as the second argument to keypath functions. See https://github.com/tictail/tide/pull/29. 
+* Add a new special property `tideOptions` on `TideComponent`. The `tideOptions` prop is an object that is supplied as the second argument to keypath functions. See https://github.com/tictail/tide/pull/29. 
 
 ### 2.0.0 2017-06-20
 * Replace `react-pure-render/shallowEqual` with `shallowequal` 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tide",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A Flux-like State Management Library for React by your friends at Tictail.",
   "main": "index.js",
   "license": "MIT",

--- a/src/component.js
+++ b/src/component.js
@@ -7,7 +7,7 @@ import Tide from './base'
 const NOT_KEY_PATH_PROPS = [
   'children',
   'tide',
-  'tideMeta',
+  'tidePointer',
   'key',
   'ref',
 ]
@@ -38,7 +38,7 @@ export default class TideComponent extends React.Component {
   }
 
   getChildContext() {
-    return {tide: this.getTide(), tideMeta: this.getTideMeta()}
+    return {tide: this.getTide(), tidePointer: this.getTidePointer()}
   }
 
   componentWillMount() {
@@ -63,7 +63,7 @@ export default class TideComponent extends React.Component {
   getKeyPaths(props, tide) {
     let keyPaths = omit(props, (key) => excludedProps[key])
     keyPaths = mapValues(keyPaths, (val, key) => {
-      const value = typeof val === 'function' ? val(tide.getState(), this.getTideMeta()) : val
+      const value = typeof val === 'function' ? val(tide.getState(), this.getTidePointer()) : val
       if (Array.isArray(value)) return value
       if (value === true) return [key]
       return value.split('.')
@@ -81,8 +81,8 @@ export default class TideComponent extends React.Component {
       this.props.tide : this.context.tide
   }
 
-  getTideMeta() {
-    return this.props.tideMeta || this.context.tideMeta || {}
+  getTidePointer() {
+    return this.props.tidePointer || this.context.tidePointer || {}
   }
 
   getChildProps() {
@@ -105,6 +105,6 @@ if (process.env.NODE_ENV !== 'production') {
   }
 }
 
-const contextTypes = {tide: PropTypes.object, tideMeta: PropTypes.object}
+const contextTypes = {tide: PropTypes.object, tidePointer: PropTypes.object}
 TideComponent.contextTypes = contextTypes
 TideComponent.childContextTypes = contextTypes

--- a/src/component.js
+++ b/src/component.js
@@ -7,7 +7,7 @@ import Tide from './base'
 const NOT_KEY_PATH_PROPS = [
   'children',
   'tide',
-  'tidePointer',
+  'tideOptions',
   'key',
   'ref',
 ]
@@ -38,7 +38,7 @@ export default class TideComponent extends React.Component {
   }
 
   getChildContext() {
-    return {tide: this.getTide(), tidePointer: this.getTidePointer()}
+    return {tide: this.getTide(), tideOptions: this.getTideOptions()}
   }
 
   componentWillMount() {
@@ -63,7 +63,7 @@ export default class TideComponent extends React.Component {
   getKeyPaths(props, tide) {
     let keyPaths = omit(props, (key) => excludedProps[key])
     keyPaths = mapValues(keyPaths, (val, key) => {
-      const value = typeof val === 'function' ? val(tide.getState(), this.getTidePointer()) : val
+      const value = typeof val === 'function' ? val(tide.getState(), this.getTideOptions()) : val
       if (Array.isArray(value)) return value
       if (value === true) return [key]
       return value.split('.')
@@ -81,8 +81,8 @@ export default class TideComponent extends React.Component {
       this.props.tide : this.context.tide
   }
 
-  getTidePointer() {
-    return this.props.tidePointer || this.context.tidePointer || {}
+  getTideOptions() {
+    return this.props.tideOptions || this.context.tideOptions || {}
   }
 
   getChildProps() {
@@ -105,6 +105,6 @@ if (process.env.NODE_ENV !== 'production') {
   }
 }
 
-const contextTypes = {tide: PropTypes.object, tidePointer: PropTypes.object}
+const contextTypes = {tide: PropTypes.object, tideOptions: PropTypes.object}
 TideComponent.contextTypes = contextTypes
 TideComponent.childContextTypes = contextTypes

--- a/src/component.js
+++ b/src/component.js
@@ -7,6 +7,7 @@ import Tide from './base'
 const NOT_KEY_PATH_PROPS = [
   'children',
   'tide',
+  'tideMeta',
   'key',
   'ref',
 ]
@@ -37,7 +38,7 @@ export default class TideComponent extends React.Component {
   }
 
   getChildContext() {
-    return {tide: this.getTide()}
+    return {tide: this.getTide(), tideMeta: this.getTideMeta()}
   }
 
   componentWillMount() {
@@ -62,7 +63,7 @@ export default class TideComponent extends React.Component {
   getKeyPaths(props, tide) {
     let keyPaths = omit(props, (key) => excludedProps[key])
     keyPaths = mapValues(keyPaths, (val, key) => {
-      const value = typeof val === 'function' ? val(tide.getState()) : val
+      const value = typeof val === 'function' ? val(tide.getState(), this.getTideMeta()) : val
       if (Array.isArray(value)) return value
       if (value === true) return [key]
       return value.split('.')
@@ -78,6 +79,10 @@ export default class TideComponent extends React.Component {
   getTide() {
     return this.props.tide instanceof Tide ?
       this.props.tide : this.context.tide
+  }
+
+  getTideMeta() {
+    return this.props.tideMeta || this.context.tideMeta || {}
   }
 
   getChildProps() {
@@ -100,6 +105,6 @@ if (process.env.NODE_ENV !== 'production') {
   }
 }
 
-const contextTypes = {tide: PropTypes.object}
+const contextTypes = {tide: PropTypes.object, tideMeta: PropTypes.object}
 TideComponent.contextTypes = contextTypes
 TideComponent.childContextTypes = contextTypes

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -136,24 +136,24 @@ describe('Component', function() {
       tideInstance.setState(state)
       const tree = React.createElement(Component, {
         tide: tideInstance,
-        fooPointer(state) { return [state.get('path')] }
+        fooPointer: (state) => [state.get('path')]
       }, Child)
 
       TestUtils.renderIntoDocument(tree)
     })
 
-    it('passes the tideMeta context to keypath functions ', function() {
+    it('passes the tidePointer context to keypath functions ', function() {
       const Child = createComponent(function() {
-        expect(this.props.metaData).toEqual('meta data')
+        expect(this.props.item).toEqual('Item A')
       })
 
-      const state = Immutable.fromJS({meta: 'meta data'})
+      const state = Immutable.fromJS({items: {a: 'Item A'}})
 
       tideInstance.setState(state)
       const tree = React.createElement(Component, {
         tide: tideInstance,
-        tideMeta: {pointer: 'meta'},
-        metaData(state, meta) { return [meta.pointer] }
+        tidePointer: {itemId: 'a'},
+        item: (state, pointer) => ['items', pointer.itemId]
       }, Child)
 
       TestUtils.renderIntoDocument(tree)

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -142,7 +142,7 @@ describe('Component', function() {
       TestUtils.renderIntoDocument(tree)
     })
 
-    it('passes the tidePointer context to keypath functions ', function() {
+    it('passes the tideOptions context to keypath functions', function() {
       const Child = createComponent(function() {
         expect(this.props.item).toEqual('Item A')
       })
@@ -152,7 +152,7 @@ describe('Component', function() {
       tideInstance.setState(state)
       const tree = React.createElement(Component, {
         tide: tideInstance,
-        tidePointer: {itemId: 'a'},
+        tideOptions: {itemId: 'a'},
         item: (state, pointer) => ['items', pointer.itemId]
       }, Child)
 

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -142,6 +142,23 @@ describe('Component', function() {
       TestUtils.renderIntoDocument(tree)
     })
 
+    it('passes the tideMeta context to keypath functions ', function() {
+      const Child = createComponent(function() {
+        expect(this.props.metaData).toEqual('meta data')
+      })
+
+      const state = Immutable.fromJS({meta: 'meta data'})
+
+      tideInstance.setState(state)
+      const tree = React.createElement(Component, {
+        tide: tideInstance,
+        tideMeta: {pointer: 'meta'},
+        metaData(state, meta) { return [meta.pointer] }
+      }, Child)
+
+      TestUtils.renderIntoDocument(tree)
+    })
+
     it('passes down keyPaths in the `tide` prop', function() {
       const Child = createComponent(function() {
         expect(this.props.tide.keyPaths.foo).toEqual(['nested', 'foo'])


### PR DESCRIPTION
#29 This adds a new prop `tideMeta` to `<TideComponent/>`. The `tideMeta` prop accepts an object that will be supplied to all keypath function calls. This gives us a way to control from the parent where data from the state should be read from, instead of needing read all the data from the parent and pass it down as props. 

```js
const Item = wrap(ItemComponent, { 
  itemData: (state, meta) => ['items', meta.itemId]
})

ReactDOM.render(
  <React.Fragment>
    <TideComponent tideMeta={{itemId: 'a'}}>
      {props => <Item {...props}/>}
    </TideComponent>
    <TideComponent tideMeta={{itemId: 'b'}}>
      {props => <Item {...props}/>}
    </TideComponent>
  </React.Fragment>
)
```

In the above example we have two tide-wrapped `<Item/>` components rendered side by side, but listening to different objects in the state. If you wanted to do dynamic paths like this previously, you would have to have a pointer in your state, like `currentItem` for example. The problem with that however is that it only works with one item at a time, you can't have two different ones rendered side by side. 

I know `tideMeta` isn't the best prop name here, but I'm not sure what to call it. It needs be prefixed with `tide` to avoid collisions with the regular path props. Maybe `tidePointer` is better to communicate how this can / should be used? 

**Update:** I changed it to `tidePointer`. 
**Update 2:** I changed it to `tideOptions`.
 