### PR TITLE
Include tideOptions in component props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.2.0 2018-02-05
+* Include `tideOptions` as `this.props.tide.options` in tide-wrapped components. 
+
 ### 2.1.0 2018-01-12
 * Add a new special property `tideOptions` on `TideComponent`. The `tideOptions` prop is an object that is supplied as the second argument to keypath functions. See https://github.com/tictail/tide/pull/29. 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tide",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A Flux-like State Management Library for React by your friends at Tictail.",
   "main": "index.js",
   "license": "MIT",

--- a/src/component.js
+++ b/src/component.js
@@ -31,6 +31,7 @@ export default class TideComponent extends React.Component {
     const keyPaths = this.getKeyPaths(props, tide)
     this._componentTide = {
       keyPaths,
+      options: this.getTideOptions(),
       ...tide.getComponentProps(),
     }
 

--- a/test/component_test.js
+++ b/test/component_test.js
@@ -159,6 +159,18 @@ describe('Component', function() {
       TestUtils.renderIntoDocument(tree)
     })
 
+    it('passes the tideOptions in the `tide` prop', function() {
+      const Child = createComponent(function() {
+        expect(this.props.tide.options.foo).toEqual('bar')
+      })
+
+      tideInstance.setState(Immutable.Map())
+      const tree = React.createElement(
+        Component, {tide: tideInstance, tideOptions: {foo: 'bar'}}, Child
+      )
+      TestUtils.renderIntoDocument(tree)
+    })
+
     it('passes down keyPaths in the `tide` prop', function() {
       const Child = createComponent(function() {
         expect(this.props.tide.keyPaths.foo).toEqual(['nested', 'foo'])

--- a/test/wrap_test.js
+++ b/test/wrap_test.js
@@ -188,7 +188,8 @@ describe('wrap', function() {
           'keyPaths': {
             'bar': ['bar'],
             'foo': ['foo']
-          }
+          },
+          'options': {}
         }
       })
       done()


### PR DESCRIPTION
As a continuation of https://github.com/tictail/tide/pull/29, we realised that there are cases where we want access to `tideOptions` as a prop inside components as well. 